### PR TITLE
Fix AUTODOCKTOOLS_UTIL env var

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -15,7 +15,7 @@ ACTIVATE=$PREFIX/etc/conda/activate.d/autodocktools.sh
 DEACTIVATE=$PREFIX/etc/conda/deactivate.d/autodocktools.sh
 
 # set up
-echo "export AUTODOCKTOOLS_UTIL=\$CONDA_DEFAULT_ENV/${UTILITIES_RPATH}"> $ACTIVATE
+echo "export AUTODOCKTOOLS_UTIL=\$CONDA_PREFIX/${UTILITIES_RPATH}"> $ACTIVATE
 
 # tear down
 echo "unset AUTODOCKTOOLS_UTIL" > $DEACTIVATE

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     sha256: 15f9f64015270bfa6fa3091c7278e442a77e73d5db6d20ffe45ae019294a3d17  # [osx]
 
 build:
-  number: 1
+  number: 2
   skip: True  # [win]
 
 test:
@@ -22,6 +22,7 @@ test:
     - prepare_receptor4.py
     - pythonsh --help
     - test ! -z $AUTODOCKTOOLS_UTIL  # [not win]
+    - test $AUTODOCKTOOLS_UTIL == ${CONDA_PREFIX}/MGLToolsPckgs/AutoDockTools/Utilities24 # [not win]
 
 about:
   home: http://mgltools.scripps.edu

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ test:
     - prepare_receptor4.py
     - pythonsh --help
     - test ! -z $AUTODOCKTOOLS_UTIL  # [not win]
-    - test $AUTODOCKTOOLS_UTIL == ${CONDA_PREFIX}/MGLToolsPckgs/AutoDockTools/Utilities24 # [not win]
+    - test $AUTODOCKTOOLS_UTIL == ${CONDA_PREFIX}/MGLToolsPckgs/AutoDockTools/Utilities24  # [not win]
 
 about:
   home: http://mgltools.scripps.edu


### PR DESCRIPTION
For local envs (i.e., in `~/.conda/envs/`) the `CONDA_DEFAULT_ENV` variable is not representing the full path to the environment, which breaks the `AUTODOCKTOOLS_UTIL` env var. The fix is here, using the `CONDA_PREFIX` env var instead.